### PR TITLE
[RW-4420] Bump alternate AoU versioning scheme, 1.2.0 is currently live

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bigrquery
 Title: An Interface to Google's 'BigQuery' 'API'
-Version: 1.2.0
+Version: 1.2.0-1
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre"),
       comment = c(ORCID = "0000-0003-4757-117X")),

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 
 # bigrquery
 
+## All of Us Patches
+
+- https://github.com/r-dbi/bigrquery/pull/353
+- https://github.com/r-dbi/bigrquery/pull/367
+
+This is currently forked from the latest production package release of 1.2.0.
+Once the above PRs are merged and released, we should remove this fork.
+
+To distinguish between this fork and the primary version, we include a "patch"
+suffix on the version number, e.g. "1.2.0-1", where the patch is the trailing
+"1". The expectation is that client will be installing this forked package via:
+
+```r
+devtools::install_github("all-of-us/bigrquery")
+```
+
 <!-- badges: start -->
 
 [![CRAN


### PR DESCRIPTION
Considerations: the bigrquery dev package appears to use a ".XXXX" suffix for development. We just use a different convention here to avoid overlapping with that.

https://precisionmedicineinitiative.atlassian.net/browse/RW-4420